### PR TITLE
added authorization header

### DIFF
--- a/haravan/base.py
+++ b/haravan/base.py
@@ -139,6 +139,7 @@ class HaravanResource(ActiveResource, mixins.Countable):
         cls.user = None
         cls.password = None
         cls.headers['X-Haravan-Access-Token'] = session.token
+        cls.headers['Authorization'] = 'Bearer ' + str(session.token)
 
     @classmethod
     def clear_session(cls):
@@ -146,3 +147,4 @@ class HaravanResource(ActiveResource, mixins.Countable):
         cls.user = None
         cls.password = None
         cls.headers.pop('X-Haravan-Access-Token', None)
+        cls.headers.pop('Authorization', None)

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -26,6 +26,8 @@ class BaseTest(TestCase):
         self.assertIsNone(ActiveResource.headers)
         self.assertEqual('token1', haravan.HaravanResource.headers['X-Haravan-Access-Token'])
         self.assertEqual('token1', haravan.Shop.headers['X-Haravan-Access-Token'])
+        self.assertEqual('Bearer token1', haravan.HaravanResource.headers['Authorization'])
+        self.assertEqual('Bearer token1', haravan.Shop.headers['Authorization'])
 
     def test_clear_session_should_clear_site_and_headers_from_Base(self):
         haravan.HaravanResource.activate_session(self.session1)
@@ -51,6 +53,8 @@ class BaseTest(TestCase):
         self.assertIsNone(ActiveResource.headers)
         self.assertEqual('token2', haravan.HaravanResource.headers['X-Haravan-Access-Token'])
         self.assertEqual('token2', haravan.Shop.headers['X-Haravan-Access-Token'])
+        self.assertEqual('Bearer token2', haravan.HaravanResource.headers['Authorization'])
+        self.assertEqual('Bearer token2', haravan.Shop.headers['Authorization'])
 
     def test_delete_should_send_custom_headers_with_request(self):
         haravan.HaravanResource.activate_session(self.session1)

--- a/test/session_test.py
+++ b/test/session_test.py
@@ -121,7 +121,7 @@ class SessionTest(TestCase):
           'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
           'timestamp': '1337178173',
           'signature': '6e39a2ea9e497af6cb806720da1f1bf3',
-          'hmac': '2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2',
+          'hmac': 'b0a5dd62e8a070491b40d5f5b6f8c82263604442293fc7a8ee21445f4263def4',
         }
         self.assertEqual(haravan.Session.calculate_hmac(params), params['hmac'])
 


### PR DESCRIPTION
# Issue
Getting below error while accessing any resource with steps given in master README.md
```
UnauthorizedAccess: Response(code=401, body="{"errors":"[API] Invalid API key or access token (unrecognized login or wrong password)"}", headers={'content-length': '89', 'expires': '-1', 'server': 'nginx', 'connection': 'close', 'pragma': 'no-cache', 'cache-control': 'no-cache', 'date': 'Thu, 07 Mar 2019 11:51:07 GMT', 'content-type': 'application/json; charset=utf-8', 'www-authenticate': 'Bearer, Basic realm="Haravan Realm"'}, msg="Unauthorized")
```
This was because of only `X-Haravan-Access-Token` was passed as header in each request.

# Changes done
1. Added `Authorization` header in each request along with existing one.
1. Added related test cases in following files -
    1. `base_test.py` for new header related changes.
    1. `session_test.py` with updated `hmac` due to new header addition. 

# Test case results
```
vivek.patel[~/Development/github/haravan_python_api]: (auth-fix)
» python setup.py test
running test
running egg_info
writing requirements to HaravanAPI.egg-info/requires.txt
writing HaravanAPI.egg-info/PKG-INFO
writing top-level names to HaravanAPI.egg-info/top_level.txt
writing dependency_links to HaravanAPI.egg-info/dependency_links.txt
reading manifest file 'HaravanAPI.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'HaravanAPI.egg-info/SOURCES.txt'
running build_ext
test_activate_session_should_set_site_and_headers_for_given_session (test.base_test.BaseTest) ... ok
test_activate_session_with_one_session_then_clearing_and_activating_with_another_session_shoul_request_to_correct_shop (test.base_test.BaseTest) ... ok
test_clear_session_should_clear_site_and_headers_from_Base (test.base_test.BaseTest) ... ok
test_delete_should_send_custom_headers_with_request (test.base_test.BaseTest) ... ok
test_headers_includes_user_agent (test.base_test.BaseTest) ... ok
test_headers_is_thread_safe (test.base_test.BaseTest) ... ok
test_create_new_fulfillment_service (test.fulfillment_service_test.FulfillmentServiceTest) ... ok
test_get_fulfillment_service (test.fulfillment_service_test.FulfillmentServiceTest) ... ok
test_set_format_attribute (test.fulfillment_service_test.FulfillmentServiceTest) ... ok
test_delete_asset_namespaced (test.asset_test.AssetTest) ... ok
test_get_asset (test.asset_test.AssetTest) ... ok
test_get_asset_namespaced (test.asset_test.AssetTest) ... ok
test_get_assets (test.asset_test.AssetTest) ... ok
test_get_assets_namespaced (test.asset_test.AssetTest) ... ok
test_update_asset (test.asset_test.AssetTest) ... ok
test_update_asset_namespaced (test.asset_test.AssetTest) ... ok
test_get_order (test.order_test.OrderTest) ... ok
test_get_order_transaction (test.order_test.OrderTest) ... ok
test_should_be_able_to_add_note_attributes_to_an_order (test.order_test.OrderTest) ... ok
test_should_be_loaded_correctly_from_order_xml (test.order_test.OrderTest) ... ok
test_all_should_return_all_carts (test.cart_test.CartTest) ... ok
test_add_metafield (test.shop_test.ShopTest) ... ok
test_current_should_return_current_shop (test.shop_test.ShopTest) ... ok
test_events (test.shop_test.ShopTest) ... ok
test_get_metafields_for_shop (test.shop_test.ShopTest) ... ok
test_should_find_a_specific_transaction (test.transaction_test.TransactionTest) ... ok
test_all_should_return_all_checkouts (test.checkout_test.CheckoutTest) ... ok
test_create_article (test.article_test.ArticleTest) ... ok
test_get_article (test.article_test.ArticleTest) ... ok
test_get_article_namespaced (test.article_test.ArticleTest) ... ok
test_get_articles (test.article_test.ArticleTest) ... ok
test_get_articles_namespaced (test.article_test.ArticleTest) ... ok
test_get_authors (test.article_test.ArticleTest) ... ok
test_get_authors_for_blog_id (test.article_test.ArticleTest) ... ok
test_get_popular_tags (test.article_test.ArticleTest) ... ok
test_get_tags (test.article_test.ArticleTest) ... ok
test_get_tags_for_blog_id (test.article_test.ArticleTest) ... ok
test_update_article (test.article_test.ArticleTest) ... ok
test_create_order_risk (test.order_risk_test.OrderRiskTest) ... ok
test_delete_order_risk (test.order_risk_test.OrderRiskTest) ... ok
test_get_order_risk (test.order_risk_test.OrderRiskTest) ... ok
test_get_order_risks (test.order_risk_test.OrderRiskTest) ... ok
test_create_image (test.image_test.ImageTest) ... ok
test_get_image (test.image_test.ImageTest) ... ok
test_get_images (test.image_test.ImageTest) ... ok
test_get_metafields_for_image (test.image_test.ImageTest) ... ok
test_able_to_cancel_fulfillment (test.fulfillment_test.FulFillmentTest) ... ok
test_able_to_complete_fulfillment (test.fulfillment_test.FulFillmentTest) ... ok
test_get_customers_from_customer_saved_search (test.customer_saved_search_test.CustomerSavedSearchTest) ... ok
test_get_customers_from_customer_saved_search_with_params (test.customer_saved_search_test.CustomerSavedSearchTest) ... ok
test_create_variant (test.variant_test.VariantTest) ... ok
test_create_variant_then_add_parent_id (test.variant_test.VariantTest) ... ok
test_get_variant (test.variant_test.VariantTest) ... ok
test_get_variant_namespaced (test.variant_test.VariantTest) ... ok
test_get_variants (test.variant_test.VariantTest) ... ok
test_update_variant_namespace (test.variant_test.VariantTest) ... ok
test_create_new_carrier_service (test.carrier_service_test.CarrierServiceTest) ... ok
test_get_carrier_service (test.carrier_service_test.CarrierServiceTest) ... ok
test_set_format_attribute (test.carrier_service_test.CarrierServiceTest) ... ok
test_add_metafields_to_product (test.product_test.ProductTest) ... ok
test_add_variant_to_product (test.product_test.ProductTest) ... ok
test_get_metafields_for_product (test.product_test.ProductTest) ... ok
test_update_loaded_variant (test.product_test.ProductTest) ... ok
test_activate_charge (test.recurring_charge_test.RecurringApplicationChargeTest) ... ok
test_current_method_returns_active_charge (test.recurring_charge_test.RecurringApplicationChargeTest) ... ok
test_current_method_returns_none_if_active_not_found (test.recurring_charge_test.RecurringApplicationChargeTest) ... ok
test_be_valid_with_any_token_and_any_url (test.session_test.SessionTest) ... ok
test_create_permission_url_returns_correct_url_with_dual_scope_no_redirect_uri (test.session_test.SessionTest) ... ok
test_create_permission_url_returns_correct_url_with_no_scope_no_redirect_uri (test.session_test.SessionTest) ... ok
test_create_permission_url_returns_correct_url_with_single_scope_and_redirect_uri (test.session_test.SessionTest) ... ok
test_create_permission_url_returns_correct_url_with_single_scope_no_redirect_uri (test.session_test.SessionTest) ... ok
test_hmac_calculation (test.session_test.SessionTest) ... ok
test_not_be_valid_without_a_url (test.session_test.SessionTest) ... ok
test_not_be_valid_without_token (test.session_test.SessionTest) ... ok
test_not_raise_error_without_params (test.session_test.SessionTest) ... ok
test_raise_error_if_hmac_does_not_match_expected (test.session_test.SessionTest) ... ok
test_raise_error_if_hmac_is_invalid (test.session_test.SessionTest) ... ok
test_raise_error_if_params_passed_but_signature_omitted (test.session_test.SessionTest) ... ok
test_raise_error_if_timestamp_is_too_old (test.session_test.SessionTest) ... ok
test_raise_exception_if_code_invalid_in_request_token (test.session_test.SessionTest) ... ok
test_return_site_for_session (test.session_test.SessionTest) ... ok
test_return_token_if_hmac_is_valid (test.session_test.SessionTest) ... ok
test_return_token_if_hmac_is_valid_but_signature_also_provided (test.session_test.SessionTest) ... ok
test_setup_api_key_and_secret_for_all_sessions (test.session_test.SessionTest) ... ok
test_temp_reset_haravan_HaravanResource_site_to_original_value (test.session_test.SessionTest) ... ok
test_temp_reset_haravan_HaravanResource_site_to_original_value_when_using_a_non_standard_port (test.session_test.SessionTest) ... ok
test_temp_works_without_currently_active_session (test.session_test.SessionTest) ... ok
test_use_https_protocol_by_default_for_all_sessions (test.session_test.SessionTest) ... ok
test_blog_creation (test.blog_test.BlogTest) ... ok

----------------------------------------------------------------------
Ran 89 tests in 0.141s

OK
```